### PR TITLE
Replace deprecated bare globals with v13 namespaced APIs

### DIFF
--- a/module/dice/hooks.mjs
+++ b/module/dice/hooks.mjs
@@ -25,7 +25,7 @@ const showTraitSelectionDialog = async (traits, rollingAgainst, rollingAgainstNa
     chosen: ''
   };
 
-  const html = await renderTemplate(template, data);
+  const html = await foundry.applications.handlebars.renderTemplate(template, data);
 
   try {
     return await foundry.applications.api.DialogV2.prompt({

--- a/module/dice/prowlers-roll.mjs
+++ b/module/dice/prowlers-roll.mjs
@@ -24,7 +24,7 @@ export class ProwlersRoll extends Roll {
   async render({ flavor, template = this.constructor.CHAT_TEMPLATE, isPrivate = false } = {}) {
     if (!this._evaluated) await this.evaluate({ allowInteractive: !isPrivate });
     const chatData = await this._prepareContext({ flavor, isPrivate });
-    return renderTemplate(template, chatData);
+    return foundry.applications.handlebars.renderTemplate(template, chatData);
   }
 
   /**
@@ -189,7 +189,7 @@ export class ProwlersRoll extends Roll {
       data.offense = options.offense
     }
 
-    const html = await renderTemplate(template, data);
+    const html = await foundry.applications.handlebars.renderTemplate(template, data);
 
     return new Promise((resolve) => {
       new Dialog({

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -332,7 +332,7 @@ export class ProwlersParagonsActor extends Actor {
 
     const template = 'systems/prowlers-and-paragons/templates/please-hold.hbs'
 
-    const html = await renderTemplate(template, {});
+    const html = await foundry.applications.handlebars.renderTemplate(template, {});
 
     const holdPlease =  new foundry.applications.api.DialogV2({
       window: {title:'Please Hold'},

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -4,7 +4,7 @@
  * @return {Promise}
  */
 export const preloadHandlebarsTemplates = async function () {
-  return loadTemplates([
+  return foundry.applications.handlebars.loadTemplates([
     // Actor partials.
     'systems/prowlers-and-paragons/templates/actor/parts/actor-perks.hbs',
     'systems/prowlers-and-paragons/templates/actor/parts/actor-flaws.hbs',

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -90,7 +90,7 @@ export class ProwlersParagonsActorSheet extends ActorSheet {
 
     // Enrich biography info for display
     // Enrichment turns text like `[[/r 1d20]]` into buttons
-    context.enrichedBiography = await TextEditor.enrichHTML(
+    context.enrichedBiography = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
       this.actor.system.biography,
       {
         // Whether to show secret blocks in the finished html
@@ -438,7 +438,7 @@ export class ProwlersParagonsActorSheet extends ActorSheet {
     // Get the type of item to create.
     const type = header.dataset.type;
     // Grab any data associated with this control.
-    const data = duplicate(header.dataset);
+    const data = foundry.utils.duplicate(header.dataset);
     // Initialize a default name.
     const name = `New ${type.capitalize()}`;
     // Prepare the item object.

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -47,7 +47,7 @@ export class ProwlersParagonsItemSheet extends ItemSheet {
 
     // Enrich description info for display
     // Enrichment turns text like `[[/r 1d20]]` into buttons
-    context.enrichedDescription = await TextEditor.enrichHTML(
+    context.enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(
       this.item.system.description,
       {
         // Whether to show secret blocks in the finished html


### PR DESCRIPTION
Swaps deprecated bare-global helpers for their Foundry v13 namespaced equivalents to clear console deprecation warnings and stay compatible with future versions. No behavioral change.

Changes (8 call sites across 6 files):
- `renderTemplate` → `foundry.applications.handlebars.renderTemplate`
- `loadTemplates` → `foundry.applications.handlebars.loadTemplates`
- `TextEditor.enrichHTML` → `foundry.applications.ux.TextEditor.implementation.enrichHTML`
- `duplicate` → `foundry.utils.duplicate`

`mergeObject` was already namespaced everywhere.

Out of scope: two `new Dialog(...)` sites (`prowlers-roll.mjs`, `actor-sheet.mjs`) are also deprecated in favor of `DialogV2`, but they require an API rework plus live testing of the roll flow, so they are left for a follow-up.

Closes #9